### PR TITLE
Add custom stylesheet to header

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -31,6 +31,7 @@ PaginatePath = "page"
 
     # Favicon file (relative to baseURL)
     favicon = "img/favicon.png"
+    css = "custom.css"
 
     # Enables custom date format (optional, the default is MM-DD-YYYY)
     # For reference to date and time templating, see:

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -23,6 +23,7 @@
   {{ "<!--[if gt IE 8]><!-->" | safeHTML }}
   <link rel="stylesheet" href="{{ .Site.BaseURL }}assets/style.css" />
   {{ "<!--<![endif]-->" | safeHTML }}
+  {{ if .Site.Params.css }}<link rel="stylesheet" href="{{ .Site.BaseURL }}{{ .Site.Params.css }}" />{{ end -}}
 </head>
 <body>
 <div class="pure-g">


### PR DESCRIPTION
This adds the option to configure a custom stylesheet which is then added to the HTML header. Readme doesn't need to be adapted imho.